### PR TITLE
Add PHP Toolbox in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A curated list of amazingly awesome PHPStorm plugins, resources and other shiny 
 * [CamelCase](https://plugins.jetbrains.com/plugin/7160-camelcase) - Switch easily between CamelCase, camelCase, snake_case and SNAKE_CASE. See Edit menu or use SHIFT + ALT + U.
 * [Lines Sorter](https://plugins.jetbrains.com/plugin/5919-lines-sorter) - Add Sort Lines action in Edit menu to sort selected lines or whole file if selection is empty.
 * [PHP Annotations](https://plugins.jetbrains.com/plugin/7320-php-annotations) - Adds support for PHP annotations
+* [PHP Toolbox](https://plugins.jetbrains.com/plugin/8133-php-toolbox) - Adds completion and typing for many libraries using dynamic returns types based on arguments
 * [RegexpTester](https://plugins.jetbrains.com/plugin/2917-regexptester) - Regular Expression Tester for IntelliJ IDEA. Allows you to experiment with Java regular expressions in a dynamic environment. 
 * [GoToTabs](https://plugins.jetbrains.com/plugin/7784-gototabs) - Go to specific tab by keyboard shortcuts (Alt/Cmd+<num>) like browser
 * [Options completion plugin](https://github.com/woru/options-completion-phpstorm-plugin) - Parses phpDocumentor's hash description and shows supported keys.  


### PR DESCRIPTION
PHP Toolbox provides type provider and method reference features, which were originally implemented in the Symfony plugin and then extracted to a separate plugin. The new plugin has support for several non-Symfony libraries (and support for more libraries is a matter of contributing the corresponding JSON files on Github).