### PR TITLE
Change Key Promoter plugin to modern version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A curated list of amazingly awesome PHPStorm plugins, resources and other shiny 
 * [Friday Mario](https://plugins.jetbrains.com/plugin/7599-fridaymario) - The first plugin in the world to gamify development in IntelliJ IDEs. Basically, it plays sounds from Mario video game on various actions. 
 * [Nyan Progress Bar](https://plugins.jetbrains.com/plugin/8575-nyan-progress-bar) - Pretty progress bars for IJ based IDEs. ![Nayan Cat Progress Bar](https://github.com/WyriHaximus/awesome-phpstorm/blob/master/images/nayan_cat.png)
 * [Power Mode II](https://plugins.jetbrains.com/plugin/8251-power-mode-ii) - Power Mode Based on the activate-power-mode atom plugin and forked from Baptiste Mesta on Github.
-* [Key promoter](https://plugins.jetbrains.com/plugin/1003-key-promoter) - Shows you how easy it is to do the same action using only keyboard (menus and toolbar button mouse clicks initiates shortcut display). Awesome to learn lots of keyboard shortcuts and forget about the mouse.
+* [Key Promoter X](https://github.com/halirutan/IntelliJ-Key-Promoter-X) - Shows you how easy it is to do the same action using only keyboard (menus and toolbar button mouse clicks initiates shortcut display). Awesome to learn lots of keyboard shortcuts and forget about the mouse.
 
 ### Languages/Formats
 


### PR DESCRIPTION
The previously linked plugin hasn't been updated in 6 years; Key Promoter X is a rewrite that is kept up to date.