### PR TITLE
Remove "Sites" section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ Embeds a code minimap similar to the one found in Sublime into the editor pane.
 * [Better Highlights](https://plugins.jetbrains.com/plugin/12895-better-highlights) - This plugin allows you to colorize/highlight comments and language keywords. Inside comments could be colorized and referenced source code, files and other comments.
 * [Scan Mode](https://plugins.jetbrains.com/plugin/15191-scan-mode) - Toggle font size and line spacing by keyboard shortcut.
 
-## Sites
-
-* [PhpStorm Tips](https://phpstorm.tips/) - Collection of tips in .gif format. By [@nikush_patel](https://twitter.com/nikush_patel)
-
 ## Twitter
 
 * [@phpstorm](https://twitter.com/phpstorm) - The official PhpStorm twitter account, they are very active and can answer almost every question you have about the IDE.


### PR DESCRIPTION
The site phpstorm.tips is not reachable anymore